### PR TITLE
Make it pollyfilable with `document-register-element`

### DIFF
--- a/read-time.js
+++ b/read-time.js
@@ -18,16 +18,18 @@
       return ['selector', 'wpm'];
     }
 
-    constructor() {
-      super();
-      this._selector = this.getAttribute('selector') || null;
-      this._wpm = Number(this.getAttribute('wpm') || 200);
-      this._connected = false;
-      if(this.attachShadow) {
-        this.attachShadow({ mode: 'open' });
-        this._root = this.shadowRoot;
+    constructor(self) {
+      // Make the element pollyfilable with `document-register-element`
+      // https://github.com/WebReflection/document-register-element#upgrading-the-constructor-context
+      self = super(self);
+      self._selector = self.getAttribute('selector') || null;
+      self._wpm = Number(self.getAttribute('wpm') || 200);
+      self._connected = false;
+      if(self.attachShadow) {
+        self.attachShadow({ mode: 'open' });
+        self._root = self.shadowRoot;
       } else {
-        this._root = this;
+        self._root = self;
       }
     }
 


### PR DESCRIPTION
https://github.com/WebReflection/document-register-element#upgrading-the-constructor-context

We need to upgrade `constructor` context. To make it work with CEv1 polyfill


Fixes https://github.com/matthewp/read-time/issues/4